### PR TITLE
conda-env 2.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,40 +1,8 @@
-{% set version = "2.5.2" %}
+{% set version = "2.6.0" %}
 
 package:
   name: conda-env
   version: {{ version }}
-
-source:
-  fn: conda-env-{{ version }}.tar.gz
-  url: https://github.com/conda/conda-env/archive/v{{ version }}.tar.gz
-  sha256: 7ca59fa861a3145e94c0d1377bf0bd78735f19123234bd3fcf4024a8f8e8ce03
-
-build:
-  number: 0
-  script: python setup.py install
-  entry_points:
-    - conda-env = conda_env.cli.main:main
-
-requirements:
-  build:
-    - python
-
-  run:
-    - python
-
-test:
-  imports:
-    - conda_env
-
-  commands:
-    - which conda-env  # [unix]
-    - where conda-env  # [win]
-    - conda env
-    - conda env -h
-    - conda env list -h
-    - conda env create -h
-    - conda env export -h
-    - conda env remove -h
 
 about:
   home: https://github.com/conda/conda-env

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,6 +4,15 @@ package:
   name: conda-env
   version: {{ version }}
 
+build:
+  number: 0
+
+test:
+  requires:
+    - python
+  commands:
+    - python -c "import os, json; j=json.loads(open(os.path.join(os.environ['CONDA_PREFIX'], 'conda-meta', 'conda-env-2.6.0-0.json')).read()); assert len(j['files']) == 0"
+
 about:
   home: https://github.com/conda/conda-env
   summary: Tools for interacting with conda environments.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,6 @@ build:
 test:
   requires:
     - python
-  commands:
-    - python -c "import os, json; j=json.loads(open(os.path.join(os.environ['CONDA_PREFIX'], 'conda-meta', 'conda-env-2.6.0-0.json')).read()); assert len(j['files']) == 0"
 
 about:
   home: https://github.com/conda/conda-env

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,0 +1,9 @@
+import json
+import os
+
+json_path = os.path.join(os.environ['CONDA_PREFIX'], 'conda-meta',
+                         'conda-env-2.6.0-0.json')
+with open(json_path) as f:
+    json_data=json.loads(f.read())
+
+assert len(json_data['files']) == 0


### PR DESCRIPTION
conda-env is now in the conda code itself.  We need an empty package for a while so that they don't conflict.  Eventually we'll get rid of the conda-env package altogether.
