### PR TITLE
MNT: Re-rendered with conda-smithy 1.7.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,6 @@ os: osx
 osx_image: beta-xcode6.1
 
 env:
-  matrix:
-    
-    - CONDA_PY=27
-    - CONDA_PY=34
-    - CONDA_PY=35
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "DjT1h7iwrnkvzU0TlwekHfj4kf0MJCfhYtcDQwG77gmWdIZuNOg7aVUoY4NW4faLGu9mo9sx2GyZnSj0H7qa0TFPMSq/nNU3POHXB9GKe2ArwNbVzQ2BWvlTJ4v39QEELnxVUb9iMlPQlZAV3nnBOQOMU/8roBalWxasUzQlcdn5X0XxXMTHsNdovDmBh8eMumb5bcHAwXjUz+mP5v4hL5WcmCq+niGhxf7N22iSFoyDh+mezxFOU29UWEON9jvexGBsn0rzlFDvFwoOsDty+sD2u1njZjD5igB9nZyipTH3UP2Yl3IapcuN6H4zQBOIBbAJ2WphGm6hdFkVsMdke7lwUyRtkO50PTeK5YONrk3EJ1iE57D/DvDIlay3D1g7wnPepWAduI1W/6pwbBvCr6ohQE96WlhQx/+bN5bIcqo+HtAUd0+jr2EkagrWXVlWaQw1/PDE9gIWaxiVaeJwS+e50odnCKrQ6BYpz58yKEbvN4fFXKBaa0e9zRLTJpzj3eWuobRHRG4n4ls0+5aS1CVa02p90kuZ3LccseY+fzifSHIJlbFMEbBipOqGADokFZTcq/0vdoWSeSEiUSrQgOAEuhV5lObgQs39v5TWphGg05JQHVwF93u6EUCP3v+yFz2WnSNwgPusYTWAyri5+Ha7TrrEj1iCJctq7MbrAUo="
@@ -25,9 +20,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Summary: Tools for interacting with conda environments.
 
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/conda-env-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/conda-env-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/conda-env-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/conda-env-feedstock)
+Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/conda-env-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/conda-env-feedstock/branch/master)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/conda-env/badges/version.svg)](https://anaconda.org/conda-forge/conda-env)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/conda-env/badges/downloads.svg)](https://anaconda.org/conda-forge/conda-env)
+
 Installing conda-env
 ====================
 
@@ -31,7 +43,6 @@ It is possible to list all of the versions of `conda-env` available on your plat
 ```
 conda search conda-env --channel conda-forge
 ```
-
 
 
 About conda-forge
@@ -67,18 +78,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/conda-env-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/conda-env-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/conda-env-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/conda-env-feedstock)
-Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/conda-env-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/conda-env-feedstock/branch/master)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/conda-env/badges/version.svg)](https://anaconda.org/conda-forge/conda-env)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/conda-env/badges/downloads.svg)](https://anaconda.org/conda-forge/conda-env)
 
 
 Updating conda-env-feedstock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,16 +4,11 @@
 
 environment:
 
-  CONDA_INSTALL_LOCN: "C:\\conda"
-
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
   # /E:ON and /V:ON options are not enabled in the batch script intepreter
   # See: http://stackoverflow.com/a/13751649/163740
   CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
 
-  # We set a default Python version for the miniconda that is to be installed. This can be
-  # overridden in the matrix definition where appropriate.
-  CONDA_PY: "27"
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -21,21 +16,11 @@ environment:
   matrix:
     - TARGET_ARCH: x86
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
       CONDA_PY: 27
-
-    - TARGET_ARCH: x86
-      CONDA_PY: 34
-
-    - TARGET_ARCH: x64
-      CONDA_PY: 34
-
-    - TARGET_ARCH: x86
-      CONDA_PY: 35
-
-    - TARGET_ARCH: x64
-      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -56,24 +41,25 @@ install:
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
-    - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
-    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+
+    # Add our channels.
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --add channels conda-forge
 
     # Add a hack to switch to `conda` version `4.1.12` before activating.
     # This is required to handle a long path activation issue.
     # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: set "OLDPATH=%PATH%"
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
     - cmd: conda install --yes --quiet conda=4.1.12
     - cmd: set "PATH=%OLDPATH%"
     - cmd: set "OLDPATH="
 
+    # Actually activate `conda`.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,22 +41,7 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 3 case(s).
-    set -x
-    export CONDA_PY=27
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_PY=34
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_PY=35
-    set +x
+# Embarking on 1 case(s).
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 EOF


### PR DESCRIPTION
As this no longer has dependencies, this drops Python from the matrix as well.